### PR TITLE
Update repository references and gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ This repository contains our generators and template files used for a basic setu
 To use the generator, call (where **demo** is the name of your new application):
 
 ```
-rails new demo $(curl -fsSL https://raw.githubusercontent.com/pandacms/generator/main/.railsrc) -m https://raw.githubusercontent.com/pandacms/generator/main/template.rb
+rails new demo $(curl -fsSL https://raw.githubusercontent.com/tastybamboo/generator/main/.railsrc) -m https://raw.githubusercontent.com/tastybamboo/generator/main/template.rb
 ```

--- a/template.rb
+++ b/template.rb
@@ -1,7 +1,7 @@
 require "open-uri"
 require "zip"
 
-gem "panda_cms"
+gem "panda-cms"
 
 # Choose a test framework
 test_framework = "minitest"
@@ -17,7 +17,7 @@ end
 
 # Download the theme and extract it into app/views
 theme = "plain24"
-theme_url = "https://github.com/pandacms/generator/raw/main/themes/#{theme}.zip"
+theme_url = "https://github.com/tastybamboo/generator/raw/main/themes/#{theme}.zip"
 puts "Downloading theme #{theme}..."
 URI.open(theme_url) do |file| # rubocop:disable Security/Open
   Zip::File.open_buffer(file) do |zip_file|


### PR DESCRIPTION
## Summary
Updates the generator to use the correct tastybamboo organization name and the correct gem name (panda-cms). This includes:

- Updated README.md to use tastybamboo/generator instead of pandacms/generator URL
- Updated template.rb to use correct gem name 'panda-cms' instead of 'panda_cms'
- Updated template.rb theme URL to point to tastybamboo/generator repository

## Test plan
- [x] Verified file syntax remains valid
- [x] Confirmed URL changes point to correct organization
- [x] Validated gem name matches published gem

🤖 Generated with [Claude Code](https://claude.ai/code)