### PR TITLE
Update template for new install generators

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -33,8 +33,7 @@ after_bundle do
   rails_command "generate rspec:install" if test_framework == "rspec"
   rails_command "generate panda:core:install"
   rails_command "generate panda:cms:install"
-  rails_command "panda:core:install:migrations"
-  rails_command "panda:cms:install:migrations"
+  run "bundle install" # Install omniauth-github added by the CMS generator
   rails_command "db:create"
   rails_command "db:migrate"
   rails_command "db:seed"


### PR DESCRIPTION
## Summary
- Remove redundant migration install rake tasks (generators handle this now)
- Add bundle install after panda:cms:install (adds omniauth-github to Gemfile)

Depends on panda-core and panda-cms install generator PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)